### PR TITLE
Respect custom attribute and messages from Validator in DbBoolean

### DIFF
--- a/src/Rules/DbBoolean.php
+++ b/src/Rules/DbBoolean.php
@@ -2,29 +2,16 @@
 
 namespace Soyhuce\Rules\Rules;
 
-use Closure;
-use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Support\Facades\Validator;
 use Soyhuce\Rules\Concerns\DatabaseRelatedRule;
-use function in_array;
-use function is_array;
 
-class DbBoolean implements ValidationRule
+class DbBoolean extends CompoundRule
 {
     use DatabaseRelatedRule;
 
-    /**
-     * @param Closure(string): \Illuminate\Translation\PotentiallyTranslatedString $fail
-     */
-    public function validate(string $attribute, mixed $value, Closure $fail): void
+    public function __construct()
     {
-        if (!is_array($value) && in_array($value, $this->booleans()->all(), true)) {
-            return;
-        }
-
-        $validator = Validator::make([], []);
-        $validator->addFailure($attribute, 'boolean');
-
-        $fail($validator->errors()->first($attribute));
+        parent::__construct([
+            'in:' . implode(',', $this->booleans()->all()),
+        ]);
     }
 }

--- a/src/Rules/DbBoolean.php
+++ b/src/Rules/DbBoolean.php
@@ -2,16 +2,46 @@
 
 namespace Soyhuce\Rules\Rules;
 
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
+use Illuminate\Support\Facades\Validator as ValidatorFacade;
+use Illuminate\Validation\Validator;
 use Soyhuce\Rules\Concerns\DatabaseRelatedRule;
+use function in_array;
+use function is_array;
 
-class DbBoolean extends CompoundRule
+class DbBoolean implements ValidationRule, ValidatorAwareRule
 {
     use DatabaseRelatedRule;
 
-    public function __construct()
+    private Validator $validator;
+
+    /**
+     * @param Closure(string): \Illuminate\Translation\PotentiallyTranslatedString $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        parent::__construct([
-            'in:' . implode(',', $this->booleans()->all()),
-        ]);
+        if (!is_array($value) && in_array($value, $this->booleans()->all(), true)) {
+            return;
+        }
+
+        $validator = ValidatorFacade::make(
+            [],
+            [],
+            $this->validator->customMessages,
+            $this->validator->customAttributes,
+        );
+
+        $validator->addFailure($attribute, 'boolean');
+
+        $fail($validator->errors()->first($attribute));
+    }
+
+    public function setValidator(Validator $validator): self
+    {
+        $this->validator = $validator;
+
+        return $this;
     }
 }

--- a/src/Rules/DbEnum.php
+++ b/src/Rules/DbEnum.php
@@ -2,6 +2,8 @@
 
 namespace Soyhuce\Rules\Rules;
 
+use function sprintf;
+
 class DbEnum extends CompoundRule
 {
     /**

--- a/src/Rules/SafePassword.php
+++ b/src/Rules/SafePassword.php
@@ -3,6 +3,7 @@
 namespace Soyhuce\Rules\Rules;
 
 use Soyhuce\Rules\Concerns\UsesSpecialChars;
+use function sprintf;
 
 class SafePassword extends CompoundRule
 {

--- a/tests/Rules/DbBooleanTest.php
+++ b/tests/Rules/DbBooleanTest.php
@@ -41,12 +41,12 @@ class DbBooleanTest extends RuleTestCase
      */
     public function messagesAreCorrectlyHandled(): void
     {
-        $this->assertFailsWithMessage('foo', new DbBoolean(), [trans('validation.boolean', ['attribute' => 'test'])]);
+        $this->assertFailsWithMessage('foo', new DbBoolean(), [trans('validation.in', ['attribute' => 'test'])]);
 
         trans()->addLines(['validation.attributes.test' => 'custom'], 'en');
-        $this->assertFailsWithMessage('foo', new DbBoolean(), ['The custom field must be true or false.']);
+        $this->assertFailsWithMessage('foo', new DbBoolean(), ['The selected custom is invalid.']);
 
-        trans()->addLines(['validation.custom.test.boolean' => 'It should be a boolean.'], 'en');
+        trans()->addLines(['validation.custom.test.in' => 'It should be a boolean.'], 'en');
         $this->assertFailsWithMessage('foo', new DbBoolean(), ['It should be a boolean.']);
     }
 

--- a/tests/Rules/DbDoubleTest.php
+++ b/tests/Rules/DbDoubleTest.php
@@ -6,6 +6,7 @@ use Soyhuce\Rules\Database\DatabaseRange;
 use Soyhuce\Rules\DbRules;
 use Soyhuce\Rules\Exceptions\Unimplemented;
 use Soyhuce\Rules\Rules\DbDouble;
+use function sprintf;
 
 /**
  * @coversNothing


### PR DESCRIPTION
This PRs update the way to check boolean in order to use custom messages and attributes defined on the root request