### PR TITLE
Add Every validation rule to validate array items

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # A set of useful validation rules for Laravel
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/soyhuce/laravel-validation-rules.svg?style=flat-square)](https://packagist.org/packages/soyhuce/laravel-validation-rules)
-[![GitHub Tests Action Status](https://img.shields.io/github/workflow/status/soyhuce/laravel-validation-rules/run-tests?label=tests)](https://github.com/soyhuce/laravel-validation-rules/actions?query=workflow%3Arun-tests+branch%3Amain)
-[![GitHub Code Style Action Status](https://img.shields.io/github/workflow/status/soyhuce/laravel-validation-rules/Check%20&%20fix%20styling?label=code%20style)](https://github.com/soyhuce/laravel-validation-rules/actions?query=workflow%3A"Check+%26+fix+styling"+branch%3Amain)
-[![GitHub PHPStan Action Status](https://img.shields.io/github/workflow/status/soyhuce/laravel-validation-rules/PHPStan?label=phpstan)](https://github.com/soyhuce/laravel-validation-rules/actions?query=workflow%3APHPStan+branch%3Amain)
+[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/soyhuce/laravel-validation-rules/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/soyhuce/laravel-validation-rules/actions/workflows/run-tests.yml)
+[![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/soyhuce/laravel-validation-rules/phpstan.yml?branch=main&label=phpstan&style=flat-square)](https://github.com/soyhuce/laravel-validation-rules/actions/workflows/phpstan.yml)
+[![GitHub PHPStan Action Status](https://img.shields.io/github/actions/workflow/status/soyhuce/laravel-validation-rules/php-cs-fixer.yml?branch=main&label=php-cs-fixer&style=flat-square)](https://github.com/soyhuce/laravel-validation-rules/actions/workflows/php-cs-fixer.yml)
 [![Total Downloads](https://img.shields.io/packagist/dt/soyhuce/laravel-validation-rules.svg?style=flat-square)](https://packagist.org/packages/soyhuce/laravel-validation-rules)
 
 Main objective of this package is to provide a set of validation rules for Laravel in order to make it easier to write validation.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,6 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Closure invoked with 2 parameters, 1 required\\.$#"
+			count: 2
+			path: src/Rules/Every.php

--- a/src/DbRules.php
+++ b/src/DbRules.php
@@ -23,6 +23,7 @@ use Soyhuce\Rules\Rules\DbUnsignedInteger;
 use Soyhuce\Rules\Rules\DbUnsignedMediumInteger;
 use Soyhuce\Rules\Rules\DbUnsignedSmallInteger;
 use Soyhuce\Rules\Rules\DbUnsignedTinyInteger;
+use Soyhuce\Rules\Rules\PendingDbEvery;
 
 class DbRules
 {
@@ -132,5 +133,10 @@ class DbRules
     public static function double(?float $min = null, ?float $max = null): DbDouble
     {
         return new DbDouble($min, $max);
+    }
+
+    public static function every(): PendingDbEvery
+    {
+        return new PendingDbEvery();
     }
 }

--- a/src/MiscRules.php
+++ b/src/MiscRules.php
@@ -2,6 +2,7 @@
 
 namespace Soyhuce\Rules;
 
+use Soyhuce\Rules\Rules\Every;
 use Soyhuce\Rules\Rules\MediumPassword;
 use Soyhuce\Rules\Rules\SafePassword;
 
@@ -15,5 +16,10 @@ class MiscRules
     public static function safePassword(): SafePassword
     {
         return new SafePassword();
+    }
+
+    public static function every(mixed ...$rules): Every
+    {
+        return new Every(array_values($rules));
     }
 }

--- a/src/Rules/DbEnum.php
+++ b/src/Rules/DbEnum.php
@@ -2,6 +2,8 @@
 
 namespace Soyhuce\Rules\Rules;
 
+use function sprintf;
+
 class DbEnum extends CompoundRule
 {
     /**

--- a/src/Rules/Every.php
+++ b/src/Rules/Every.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Soyhuce\Rules\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Facades\Validator as ValidatorFacade;
+use function is_array;
+
+class Every implements ValidationRule
+{
+    /**
+     * @param array<int, mixed> $rules
+     */
+    public function __construct(
+        protected array $rules,
+    ) {
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (!is_array($value)) {
+            return;
+        }
+
+        $validator = ValidatorFacade::make(
+            [$attribute => $value],
+            [
+                $attribute => 'array',
+                "{$attribute}.*" => $this->rules,
+            ],
+        );
+
+        $failed = false;
+
+        foreach ($validator->errors()->messages() as $key => $errors) {
+            foreach ($errors as $error) {
+                $failed = true;
+                $fail($key, $error);
+            }
+        }
+
+        if ($failed) {
+            $fail($attribute, 'validation.every')->translate();
+        }
+    }
+}

--- a/src/Rules/PendingDbEvery.php
+++ b/src/Rules/PendingDbEvery.php
@@ -1,0 +1,114 @@
+<?php declare(strict_types=1);
+
+namespace Soyhuce\Rules\Rules;
+
+class PendingDbEvery
+{
+    public function string(int $max = 255): Every
+    {
+        return new Every([new DbString($max)]);
+    }
+
+    public function boolean(): Every
+    {
+        return new Every([new DbBoolean()]);
+    }
+
+    /**
+     * @param array<string> $values
+     */
+    public function enum(array $values): Every
+    {
+        return new Every([new DbEnum($values)]);
+    }
+
+    public function date(): Every
+    {
+        return new Every([new DbDate()]);
+    }
+
+    public function dateTime(): Every
+    {
+        return new Every([new DbDateTime()]);
+    }
+
+    public function tinyInteger(?int $min = null, ?int $max = null): Every
+    {
+        return new Every([new DbTinyInteger($min, $max)]);
+    }
+
+    public function unsignedTinyInteger(?int $min = null, ?int $max = null): Every
+    {
+        return new Every([new DbUnsignedTinyInteger($min, $max)]);
+    }
+
+    public function smallInteger(?int $min = null, ?int $max = null): Every
+    {
+        return new Every([new DbSmallInteger($min, $max)]);
+    }
+
+    public function unsignedSmallInteger(?int $min = null, ?int $max = null): Every
+    {
+        return new Every([new DbUnsignedSmallInteger($min, $max)]);
+    }
+
+    public function mediumInteger(?int $min = null, ?int $max = null): Every
+    {
+        return new Every([new DbMediumInteger($min, $max)]);
+    }
+
+    public function unsignedMediumInteger(?int $min = null, ?int $max = null): Every
+    {
+        return new Every([new DbUnsignedMediumInteger($min, $max)]);
+    }
+
+    public function integer(?int $min = null, ?int $max = null): Every
+    {
+        return new Every([new DbInteger($min, $max)]);
+    }
+
+    public function unsignedInteger(?int $min = null, ?int $max = null): Every
+    {
+        return new Every([new DbUnsignedInteger($min, $max)]);
+    }
+
+    public function bigInteger(?int $min = null, ?int $max = null): Every
+    {
+        return new Every([new DbBigInteger($min, $max)]);
+    }
+
+    public function unsignedBigInteger(?int $min = null, ?int $max = null): Every
+    {
+        return new Every([new DbUnsignedBigInteger($min, $max)]);
+    }
+
+    public function smallIncrements(?int $min = null, ?int $max = null): Every
+    {
+        return new Every([new DbSmallIncrements($min, $max)]);
+    }
+
+    public function mediumIncrements(?int $min = null, ?int $max = null): Every
+    {
+        return new Every([new DbMediumIncrements($min, $max)]);
+    }
+
+    public function increments(?int $min = null, ?int $max = null): Every
+    {
+        return new Every([new DbIncrements($min, $max)]);
+    }
+
+    public function bigIncrements(?int $min = null, ?int $max = null): Every
+    {
+        return new Every([new DbBigIncrements($min, $max)]);
+    }
+
+    public function float(?float $min = null, ?float $max = null): Every
+    {
+        return new Every([new DbFloat($min, $max)]);
+    }
+
+    public function double(?float $min = null, ?float $max = null): Every
+    {
+        return new Every([new DbDouble($min, $max)]);
+    }
+}

--- a/src/Rules/SafePassword.php
+++ b/src/Rules/SafePassword.php
@@ -3,6 +3,7 @@
 namespace Soyhuce\Rules\Rules;
 
 use Soyhuce\Rules\Concerns\UsesSpecialChars;
+use function sprintf;
 
 class SafePassword extends CompoundRule
 {

--- a/tests/Rules/DbDoubleTest.php
+++ b/tests/Rules/DbDoubleTest.php
@@ -6,6 +6,7 @@ use Soyhuce\Rules\Database\DatabaseRange;
 use Soyhuce\Rules\DbRules;
 use Soyhuce\Rules\Exceptions\Unimplemented;
 use Soyhuce\Rules\Rules\DbDouble;
+use function sprintf;
 
 /**
  * @coversNothing

--- a/tests/Rules/EveryTest.php
+++ b/tests/Rules/EveryTest.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+
+namespace Rules;
+
+use Illuminate\Http\UploadedFile;
+use Soyhuce\Rules\MiscRules;
+use Soyhuce\Rules\Rules\DbUnsignedTinyInteger;
+use Soyhuce\Rules\Rules\Every;
+use Soyhuce\Rules\Tests\Rules\RuleTestCase;
+
+/**
+ * @coversNothing
+ */
+class EveryTest extends RuleTestCase
+{
+    /**
+     * @test
+     */
+    public function theRuleCorrectlyValidates(): void
+    {
+        $this->assertValidates([10], new Every([new DbUnsignedTinyInteger()]));
+        $this->assertValidates([0, 10], new Every([new DbUnsignedTinyInteger()]));
+        $this->assertValidates(range(0, 255), new Every([new DbUnsignedTinyInteger()]));
+
+        $this->assertNotValidates([-1], new Every([new DbUnsignedTinyInteger()]));
+        $this->assertNotValidates([256, 0, 10], new Every([new DbUnsignedTinyInteger()]));
+
+        $this->assertValidates(
+            ['foo@email.com', 'bar@email.com', 'baz@email.com'],
+            new Every(['required', 'string', 'email'])
+        );
+        $this->assertNotValidates(
+            ['foo@email.com', 'bar@email.com', 'baz@email.com', 3],
+            new Every(['required', 'string', 'email'])
+        );
+
+        $this->assertValidates(null, ['nullable', 'array', new Every([new DbUnsignedTinyInteger()])]);
+        $this->assertNotValidates(null, ['required', 'array', new Every([new DbUnsignedTinyInteger()])]);
+    }
+
+    /**
+     * @test
+     */
+    public function messagesAreCorrectlyHandled(): void
+    {
+        $this->assertFailsWithMessage(
+            [-1],
+            new Every([new DbUnsignedTinyInteger()]),
+            [trans('validation.every', ['attribute' => 'test'])]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function subMessagesArePresent(): void
+    {
+        $this->assertEquals(
+            [
+                'test' => [trans('validation.every', ['attribute' => 'test'])],
+                'test.0' => [trans('validation.email', ['attribute' => 'test.0'])],
+                'test.1' => [trans('validation.email', ['attribute' => 'test.1'])],
+                'test.2' => [trans('validation.required', ['attribute' => 'test.2'])],
+            ],
+            $this->makeValidator(
+                ['foo', UploadedFile::fake()->create('test.txt'), null],
+                ['array', new Every(['required', 'email'])]
+            )
+                ->getMessageBag()
+                ->getMessages()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function helperCanBeUsed(): void
+    {
+        $this->assertValidates([10], MiscRules::every(new DbUnsignedTinyInteger()));
+    }
+}

--- a/tests/Rules/EveryTest.php
+++ b/tests/Rules/EveryTest.php
@@ -9,7 +9,7 @@ use Soyhuce\Rules\Rules\Every;
 use Soyhuce\Rules\Tests\Rules\RuleTestCase;
 
 /**
- * @coversNothing
+ * @covers \Soyhuce\Rules\Rules\Every
  */
 class EveryTest extends RuleTestCase
 {

--- a/tests/Rules/PendingDbEveryTest.php
+++ b/tests/Rules/PendingDbEveryTest.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace Rules;
+
+use Illuminate\Validation\Rule;
+use Soyhuce\Rules\DbRules;
+use Soyhuce\Rules\Rules\Every;
+use Soyhuce\Rules\Tests\Rules\RuleTestCase;
+
+/**
+ * @covers \Soyhuce\Rules\Rules\PendingDbEvery
+ */
+class PendingDbEveryTest extends RuleTestCase
+{
+    /**
+     * @test
+     */
+    public function theRuleCorrectlyValidates(): void
+    {
+        $this->assertValidates([10], DbRules::every()->unsignedTinyInteger());
+        $this->assertValidates([0, 10], DbRules::every()->unsignedTinyInteger());
+        $this->assertValidates(range(0, 255), DbRules::every()->unsignedTinyInteger());
+
+        $this->assertNotValidates([-1], DbRules::every()->unsignedTinyInteger());
+        $this->assertNotValidates([256, 0, 10], DbRules::every()->unsignedTinyInteger());
+
+        $this->assertValidates(
+            ['foo@email.com', 'bar@email.com', 'baz@email.com'],
+            new Every(['required', 'string', 'email'])
+        );
+        $this->assertNotValidates(
+            ['foo@email.com', 'bar@email.com', 'baz@email.com', 3],
+            new Every(['required', 'string', 'email'])
+        );
+
+        $this->assertValidates(null, ['nullable', 'array', DbRules::every()->unsignedTinyInteger()]);
+        $this->assertNotValidates(null, ['required', 'array', DbRules::every()->unsignedTinyInteger()]);
+    }
+
+    /**
+     * @test
+     */
+    public function itDoesNotRunDatabaseValidationIfValueIsNotCorrect(): void
+    {
+        $this->assertNotValidates(
+            [1, 2, -1],
+            [
+                'required',
+                'array',
+                DbRules::every()->unsignedTinyInteger(),
+                Rule::exists('users', 'id'),
+            ]
+        );
+    }
+}

--- a/tests/Rules/RuleTestCase.php
+++ b/tests/Rules/RuleTestCase.php
@@ -12,7 +12,7 @@ use Soyhuce\Rules\Tests\TestCase;
 class RuleTestCase extends TestCase
 {
     /**
-     * @return \Illuminate\Contracts\Validation\Validator
+     * @return ValidatorContract
      */
     protected function makeValidator(mixed $value, mixed $rule)
     {


### PR DESCRIPTION
Before : 
```php
public function rules(): array
{
    return [
        'user_ids' => ['required', 'array'],
        'user_ids.*' => [DbRules::increments(), Rule::exists('users', 'id')],
    ];
}
```
after : 
```php
public function rules(): array
{
    return [
        'user_ids' => ['required', 'array', DbRules::every()->increments(), Rule::exists('users', 'id')],
    ];
}
```
This allows verification of database existence using a single query, instead of multiple ones